### PR TITLE
Add retry logic for folder creation confirmation

### DIFF
--- a/main.py
+++ b/main.py
@@ -216,13 +216,23 @@ def create_folder(profile_id: str, name: str, do: int, status: int) -> Optional[
         )
         
         # Re-fetch the list and pick the folder we just created
-        data = _api_get(f"{API_BASE}/{profile_id}/groups").json()
-        for grp in data["body"]["groups"]:
-            if grp["group"].strip() == name.strip():
-                log.info("Created folder '%s' (ID %s)", name, grp["PK"])
-                time.sleep(FOLDER_CREATION_DELAY)
-                return str(grp["PK"])
-        
+        # Retry up to 5 times — folder may not appear immediately due to eventual consistency
+        for attempt in range(5):
+            data = _api_get(f"{API_BASE}/{profile_id}/groups").json()
+            for grp in data["body"]["groups"]:
+                if grp["group"].strip() == name.strip():
+                    log.info("Created folder '%s' (ID %s)", name, grp["PK"])
+                    time.sleep(FOLDER_CREATION_DELAY)
+                    return str(grp["PK"])
+
+            if attempt < 4:
+                wait = 2 * (attempt + 1)
+                log.warning(
+                    "Folder '%s' not yet visible (attempt %d/5), waiting %ds...",
+                    name, attempt + 1, wait,
+                )
+                time.sleep(wait)
+
         log.error(f"Folder '{name}' was not found after creation")
         return None
     except (httpx.HTTPError, KeyError) as e:


### PR DESCRIPTION
Implement retry mechanism for folder visibility after creation

ControlD's API can be eventually consistent — after creating a folder via POST,
the subsequent GET request to retrieve the folder list may not include the newly
created folder immediately. This causes a spurious "Folder 'X' was not found
after creation" error.

This change adds a retry loop (up to 5 attempts with progressive 2s/4s/6s/8s delays)
when the folder isn't found in the response, fixing the race condition at its
source. After 5 failed attempts, it logs the error and returns None as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of folder creation by implementing retry logic to handle API eventual consistency delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->